### PR TITLE
fixed rule-based decision tree duplication

### DIFF
--- a/Steam_Search/algorithms_B.cpp
+++ b/Steam_Search/algorithms_B.cpp
@@ -48,7 +48,11 @@ BucketLevel algorithms_b::setBucket(string& selected, string& candidate, unorder
 }
 
 algorithms_b::algorithms_b()
-{}
+{
+    processed.clear();
+    buckets.clear();
+    scores.clear();
+}
 
 // allows us to see if the savedHeap is exhausted, useful to decisionTreeNext logic in main
 bool algorithms_b::isHeapEmpty()
@@ -108,12 +112,18 @@ vector<string> algorithms_b::decisionTree(string& selected, unordered_map<string
     }
 
     // iterate through the candidates container and for each candidate decide which bucket it belongs in
-    int chunk = 1000 > num_games ? 1000 : num_games;
+    int chunk = 1000;
     for (int i = 0; i < chunk; i++) // chunks the candidates evaluated to avoid prolonged computation
     {
+        if (processed.contains(savedHeap.top().second))
+        {
+            savedHeap.pop();
+            continue;
+        }
         string name = savedHeap.top().second;
         savedHeap.pop();
         BucketLevel level = setBucket(selected, name, gameData, scores);
+        processed.insert(savedHeap.top().second);
         buckets[level].push_back(name);
     }
 
@@ -141,13 +151,20 @@ vector<string> algorithms_b::decisionTree(string& selected, unordered_map<string
 // this function allows for us to compute more games if the user exhausts the previous chunk of games
 vector<string> algorithms_b::decisionTreeNext(string& selected, unordered_map<string, Game>& gameData, int num_games)
 {
+    buckets.clear();
     // iterate through the candidates container and for each candidate decide which bucket it belongs in
-    int chunk = 1000 > num_games ? 1000 : num_games;
+    int chunk = 1000;
     for (int i = 0; i < chunk; i++) // chunks the candidates evaluated to avoid prolonged computation
     {
+        if (processed.contains(savedHeap.top().second))
+        {
+            savedHeap.pop();
+            continue;
+        }
         string name = savedHeap.top().second;
         savedHeap.pop();
         BucketLevel level = setBucket(selected, name, gameData, scores);
+        processed.insert(savedHeap.top().second);
         buckets[level].push_back(name);
     }
 

--- a/Steam_Search/algorithms_B.h
+++ b/Steam_Search/algorithms_B.h
@@ -30,6 +30,7 @@ private:
     priority_queue<pair<double, string>> savedHeap;
     unordered_map<string, double> scores;
     map<BucketLevel, vector<string>> buckets;
+    unordered_set<string> processed;
     BucketLevel setBucket(string& selected, string& candidate, unordered_map<string, Game>& gameData, unordered_map<string, double> scores);
 public:
     algorithms_b();

--- a/Steam_Search/main.cpp
+++ b/Steam_Search/main.cpp
@@ -105,6 +105,12 @@ int main()
         int num_games;
         cin >> num_games;
 
+        if (choice == 2 && num_games > 500)
+        {
+            num_games = 500;
+            cout << num_games << " is an invalid display amount... Printing 500 games\n" << endl;
+        }
+
         if (num_games <= 0) {
             cout << "Invalid number of games... Printing 1 game\n" << endl;
             num_games = 1;
@@ -262,7 +268,6 @@ int main()
             break;
 
         case 3: // Min Hash
-            // TODO: check for any bugs
             //minhashing preprep
                 allSignatures.clear();
 


### PR DESCRIPTION
repeated steps were seeing duplicate entries. That has been fixed but capacity has been cut in half to 500 from 1000 per process. However the processing time has also halved so overall it hasn't changed much.